### PR TITLE
Add trailing slash to rooturl

### DIFF
--- a/modules/pcci/templates/config.py.erb
+++ b/modules/pcci/templates/config.py.erb
@@ -1,7 +1,7 @@
 password = "<%= @github_password %>"
 workers = <%= @worker_count %>
 logpath = '/var/www/html/buildlogs/'
-rooturl = 'http://ci.puppet.community/buildlogs'
+rooturl = 'http://ci.puppet.community/buildlogs/'
 commentable = ['puppetlabs-rabbitmq',
                'puppetlabs-inifile',
                'puppetlabs-stdlib',


### PR DESCRIPTION
This trailing slash was removed accidentally when rooturl was changed
to ci.puppet.community.
