### PR TITLE
Don't specify a group for cron resource

### DIFF
--- a/modules/buildlogs/manifests/init.pp
+++ b/modules/buildlogs/manifests/init.pp
@@ -43,7 +43,6 @@ class buildlogs () {
   cron { 'clean old logs':
     command => 'find /var/www/html/buildlogs -type f -mtime +30 -delete >/dev/null 2>&1',
     user    => 'pcci',
-    group   => 'pcci',
     minute  => 0,
     hour    => 0,
   }


### PR DESCRIPTION
The cron resource doesn't support a 'group' parameter and you get an
error like:

```
Error: Invalid parameter group on Cron[clean old logs] at
/root/pcci-configuration/modules/buildlogs/manifests/init.pp:49 on node
planck.nibalizer.com
```
