### PR TITLE
Revert ""Comment apache""

### DIFF
--- a/modules/pcci/templates/config.py.erb
+++ b/modules/pcci/templates/config.py.erb
@@ -8,7 +8,6 @@ commentable = ['puppet-corosync',
                'puppet-apt',
                'puppet-collectd',
                'puppet-module-puppetboard',
-               'puppetlabs-apache',
                'puppetlabs-mysql',
                'puppetlabs-inifile'
                ]


### PR DESCRIPTION
Reverts puppet-community/pcci-configuration#18

We don't have access to comment on apache yet. @hunner can probably fix that when he gets back from australia.
